### PR TITLE
Use dirname(@__FILE__) in tests instead of Pkg.dir

### DIFF
--- a/test/urange.jl
+++ b/test/urange.jl
@@ -1,6 +1,6 @@
 module ModU
 
-include(Pkg.dir("CustomUnitRanges", "src", "URange.jl"))
+include(joinpath(dirname(@__FILE__), "..", "src", "URange.jl"))
 
 end
 

--- a/test/zerorange.jl
+++ b/test/zerorange.jl
@@ -1,6 +1,6 @@
 module ModZ
 
-include(Pkg.dir("CustomUnitRanges", "src", "ZeroRange.jl"))
+include(joinpath(dirname(@__FILE__), "..", "src", "ZeroRange.jl"))
 
 end
 

--- a/test/zeroto.jl
+++ b/test/zeroto.jl
@@ -1,6 +1,6 @@
 module ModZT
 
-include(Pkg.dir("CustomUnitRanges", "src", "ZeroTo.jl"))
+include(joinpath(dirname(@__FILE__), "..", "src", "ZeroTo.jl"))
 
 end
 


### PR DESCRIPTION
this will at least allow this packages' own tests to pass if it gets installed elsewhere - it won't help if other packages start referring to this one's location by `Pkg.dir("CustomUnitRanges")`, so you should probably actually consider defining module-level constants that provide the absolute paths.
